### PR TITLE
fix(portfolio): keep custom pixel cursor on interactive elements

### DIFF
--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -98,6 +98,16 @@ a { color: inherit; text-decoration: none; }
 }
 
 /* ---------- Cursor ---------- */
+/* Keep the custom pixel cursor on every interactive element. The UA stylesheet
+   forces `pointer` on links/buttons, overriding the inherited `cursor: none`
+   from <body>. Re-assert `none` so .pix-cursor shows everywhere. Component
+   cursors (e.g. the tweaks panel move/resize) use class selectors and still
+   win on specificity. */
+a, button, input, select, textarea, label, summary,
+[role="button"], [role="link"], [tabindex] {
+  cursor: none;
+}
+
 .pix-cursor {
   position: fixed; top: 0; left: 0; width: 24px; height: 24px;
   pointer-events: none; z-index: 10000;


### PR DESCRIPTION
## Summary

On hover, certain interactive elements (links/buttons) showed the native `pointer` (hand) cursor, breaking the site's custom pixel cursor (`.pix-cursor`).

`cursor` is inherited, so `html, body { cursor: none }` covers most of the page, but the UA stylesheet forces `pointer` on links/buttons. The previous approach re-asserted `cursor: none` per component (`.btn`, topbar nav, etc.) and missed some elements.

This replaces the whack-a-mole patching with a single low-specificity rule that re-asserts `cursor: none` on all interactive elements — covering current and future ones.

## Changes

| File | Change |
|------|--------|
| `src/portfolio.css` | Add one global rule setting `cursor: none` on `a, button, input, select, textarea, label, summary, [role="button"], [role="link"], [tabindex]` |

## Why low specificity is safe

The new rule is element-level (specificity `0,0,1`). Component-specific cursors that are intentional — e.g. the tweaks panel drag handle (`cursor: move`) and slider labels (`cursor: ew-resize`) — use class selectors (`0,1,0`) and still win. No deliberate cursor is overridden.

## Test plan

- [ ] `npm run dev` and hover over the buttons/links that previously showed the hand cursor → the custom pixel cursor stays
- [ ] Tweaks panel (Alt+T): drag handle still shows `move`, slider labels still show `ew-resize`
- [x] CSS-only change; no TypeScript/build impact
- [x] Commit is GPG-signed (Verified)

> Note: visual hover behavior was not verified in this environment (no browser preview available); please confirm on the dev preview.
